### PR TITLE
Simplify AWS CDK Constructs

### DIFF
--- a/broker/eventbridge/awscdk.go
+++ b/broker/eventbridge/awscdk.go
@@ -169,12 +169,16 @@ func NewServerlessApp() *ServerlessApp {
 	return &ServerlessApp{App: app}
 }
 
-func (app *ServerlessApp) NewStack(name string) *ServerlessStack {
+func (app *ServerlessApp) NewStack(name string, props ...*awscdk.StackProps) *ServerlessStack {
 	config := &awscdk.StackProps{
 		Env: &awscdk.Environment{
 			Account: jsii.String(os.Getenv("CDK_DEFAULT_ACCOUNT")),
 			Region:  jsii.String(os.Getenv("CDK_DEFAULT_REGION")),
 		},
+	}
+
+	if len(props) == 1 {
+		config = props[0]
 	}
 
 	return NewServerlessStack(app.App, jsii.String(name), &ServerlessStackProps{

--- a/broker/eventbridge/awscdk.go
+++ b/broker/eventbridge/awscdk.go
@@ -10,7 +10,6 @@ package eventbridge
 
 import (
 	"os"
-	"strconv"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsevents"
@@ -18,6 +17,7 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/aws/jsii-runtime-go"
+	"github.com/fogfish/guid"
 	"github.com/fogfish/scud"
 )
 
@@ -106,8 +106,7 @@ type ServerlessStackProps struct {
 
 type ServerlessStack struct {
 	awscdk.Stack
-	bus   awsevents.IEventBus
-	sinks []*Sink
+	bus awsevents.IEventBus
 }
 
 func NewServerlessStack(app awscdk.App, id *string, props *ServerlessStackProps) *ServerlessStack {
@@ -149,10 +148,9 @@ func (stack *ServerlessStack) NewSink(props *SinkProps) *Sink {
 
 	props.System = stack.bus
 
-	name := "Sink" + strconv.Itoa(len(stack.sinks))
+	name := "Sink" + guid.L.K(guid.Clock).String()
 	sink := NewSink(stack.Stack, jsii.String(name), props)
 
-	stack.sinks = append(stack.sinks, sink)
 	return sink
 }
 

--- a/broker/eventbridge/awscdk.go
+++ b/broker/eventbridge/awscdk.go
@@ -32,11 +32,7 @@ type Sink struct {
 	Handler awslambda.IFunction
 }
 
-/*
-
-SinkProps ...
-https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
-*/
+// See https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-patterns.html
 type SinkProps struct {
 	System     awsevents.IEventBus
 	Source     []string
@@ -45,10 +41,6 @@ type SinkProps struct {
 	Lambda     *scud.FunctionGoProps
 }
 
-/*
-
-NewSink ...
-*/
 func NewSink(scope constructs.Construct, id *string, props *SinkProps) *Sink {
 	sink := &Sink{Construct: constructs.NewConstruct(scope, id)}
 
@@ -170,18 +162,10 @@ func (stack *ServerlessStack) NewSink(props *SinkProps) *Sink {
 //
 //------------------------------------------------------------------------------
 
-/*
-
-ServerlessApp ...
-*/
 type ServerlessApp struct {
 	awscdk.App
 }
 
-/*
-
-NewServerlessApp ...
-*/
 func NewServerlessApp() *ServerlessApp {
 	app := awscdk.NewApp(nil)
 	return &ServerlessApp{App: app}
@@ -202,7 +186,6 @@ func (app *ServerlessApp) NewStack(name string) *ServerlessStack {
 	})
 }
 
-//
 func FromContext(app awscdk.App, key string) string {
 	val := app.Node().TryGetContext(jsii.String(key))
 	switch v := val.(type) {
@@ -213,7 +196,6 @@ func FromContext(app awscdk.App, key string) string {
 	}
 }
 
-//
 func FromContextVsn(app awscdk.App) string {
 	vsn := FromContext(app, "vsn")
 	if vsn == "" {

--- a/broker/events3/awscdk.go
+++ b/broker/events3/awscdk.go
@@ -133,12 +133,16 @@ func NewServerlessApp() *ServerlessApp {
 	return &ServerlessApp{App: app}
 }
 
-func (app *ServerlessApp) NewStack(name string) *ServerlessStack {
+func (app *ServerlessApp) NewStack(name string, props ...*awscdk.StackProps) *ServerlessStack {
 	config := &awscdk.StackProps{
 		Env: &awscdk.Environment{
 			Account: jsii.String(os.Getenv("CDK_DEFAULT_ACCOUNT")),
 			Region:  jsii.String(os.Getenv("CDK_DEFAULT_REGION")),
 		},
+	}
+
+	if len(props) == 1 {
+		config = props[0]
 	}
 
 	return NewServerlessStack(app.App, jsii.String(name), &ServerlessStackProps{

--- a/broker/events3/awscdk_test.go
+++ b/broker/events3/awscdk_test.go
@@ -6,7 +6,7 @@
 // https://github.com/fogfish/swarm
 //
 
-package eventbridge_test
+package events3_test
 
 import (
 	"testing"
@@ -14,30 +14,29 @@ import (
 	"github.com/aws/aws-cdk-go/awscdk/v2/assertions"
 	"github.com/aws/jsii-runtime-go"
 	"github.com/fogfish/scud"
-	"github.com/fogfish/swarm/broker/eventbridge"
+	"github.com/fogfish/swarm/broker/events3"
 )
 
 func TestEventBridgeCDK(t *testing.T) {
-	app := eventbridge.NewServerlessApp()
-	stack := app.NewStack("swarm-example-eventbridge", nil)
-	stack.NewEventBus()
+	app := events3.NewServerlessApp()
+	stack := app.NewStack("swarm-example-events3", nil)
+	stack.NewBucket()
 
 	stack.NewSink(
-		&eventbridge.SinkProps{
-			Source: []string{"swarm-example-eventbridge"},
+		&events3.SinkProps{
 			Lambda: &scud.FunctionGoProps{
 				SourceCodePackage: "github.com/fogfish/swarm",
-				SourceCodeLambda:  "examples/eventbridge/dequeue",
+				SourceCodeLambda:  "examples/events3/dequeue",
 			},
 		},
 	)
 
 	require := map[*string]*float64{
-		jsii.String("AWS::Events::EventBus"): jsii.Number(1),
-		jsii.String("AWS::Events::Rule"):     jsii.Number(1),
-		jsii.String("AWS::IAM::Role"):        jsii.Number(2),
-		jsii.String("AWS::Lambda::Function"): jsii.Number(2),
-		jsii.String("Custom::LogRetention"):  jsii.Number(1),
+		jsii.String("AWS::S3::Bucket"):               jsii.Number(1),
+		jsii.String("Custom::S3BucketNotifications"): jsii.Number(1),
+		jsii.String("AWS::IAM::Role"):                jsii.Number(3),
+		jsii.String("AWS::Lambda::Function"):         jsii.Number(3),
+		jsii.String("Custom::LogRetention"):          jsii.Number(1),
 	}
 
 	template := assertions.Template_FromStack(stack.Stack, nil)

--- a/broker/eventsqs/awscdk.go
+++ b/broker/eventsqs/awscdk.go
@@ -33,17 +33,11 @@ type Sink struct {
 	Handler awslambda.IFunction
 }
 
-/*
-SinkProps ...
-*/
 type SinkProps struct {
 	Queue  awssqs.IQueue
 	Lambda *scud.FunctionGoProps
 }
 
-/*
-NewSink ...
-*/
 func NewSink(scope constructs.Construct, id *string, props *SinkProps) *Sink {
 	sink := &Sink{Construct: constructs.NewConstruct(scope, id)}
 
@@ -134,16 +128,10 @@ func (stack *ServerlessStack) NewSink(props *SinkProps) *Sink {
 //
 //------------------------------------------------------------------------------
 
-/*
-ServerlessApp ...
-*/
 type ServerlessApp struct {
 	awscdk.App
 }
 
-/*
-NewServerlessApp ...
-*/
 func NewServerlessApp() *ServerlessApp {
 	app := awscdk.NewApp(nil)
 	return &ServerlessApp{App: app}

--- a/broker/eventsqs/awscdk.go
+++ b/broker/eventsqs/awscdk.go
@@ -135,12 +135,16 @@ func NewServerlessApp() *ServerlessApp {
 	return &ServerlessApp{App: app}
 }
 
-func (app *ServerlessApp) NewStack(name string) *ServerlessStack {
+func (app *ServerlessApp) NewStack(name string, props ...*awscdk.StackProps) *ServerlessStack {
 	config := &awscdk.StackProps{
 		Env: &awscdk.Environment{
 			Account: jsii.String(os.Getenv("CDK_DEFAULT_ACCOUNT")),
 			Region:  jsii.String(os.Getenv("CDK_DEFAULT_REGION")),
 		},
+	}
+
+	if len(props) == 1 {
+		config = props[0]
 	}
 
 	return NewServerlessStack(app.App, jsii.String(name), &ServerlessStackProps{

--- a/broker/eventsqs/awscdk.go
+++ b/broker/eventsqs/awscdk.go
@@ -10,7 +10,6 @@ package eventsqs
 
 import (
 	"os"
-	"strconv"
 
 	"github.com/aws/aws-cdk-go/awscdk/v2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awslambda"
@@ -19,6 +18,7 @@ import (
 	"github.com/aws/constructs-go/constructs/v10"
 	"github.com/aws/jsii-runtime-go"
 
+	"github.com/fogfish/guid"
 	"github.com/fogfish/scud"
 )
 
@@ -66,7 +66,6 @@ type ServerlessStackProps struct {
 type ServerlessStack struct {
 	awscdk.Stack
 	queue awssqs.IQueue
-	sinks []*Sink
 }
 
 func NewServerlessStack(app awscdk.App, id *string, props *ServerlessStackProps) *ServerlessStack {
@@ -115,10 +114,9 @@ func (stack *ServerlessStack) NewSink(props *SinkProps) *Sink {
 
 	props.Queue = stack.queue
 
-	name := "Sink" + strconv.Itoa(len(stack.sinks))
+	name := "Sink" + guid.L.K(guid.Clock).String()
 	sink := NewSink(stack.Stack, jsii.String(name), props)
 
-	stack.sinks = append(stack.sinks, sink)
 	return sink
 }
 

--- a/broker/eventsqs/awscdk_test.go
+++ b/broker/eventsqs/awscdk_test.go
@@ -11,7 +11,6 @@ package eventsqs_test
 import (
 	"testing"
 
-	"github.com/aws/aws-cdk-go/awscdk/v2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/assertions"
 	"github.com/aws/jsii-runtime-go"
 	"github.com/fogfish/scud"
@@ -19,14 +18,8 @@ import (
 )
 
 func TestEventBridgeCDK(t *testing.T) {
-	app := awscdk.NewApp(nil)
-	stack := eventsqs.NewServerlessStack(app,
-		jsii.String("swarm-example-eventsqs"),
-		&eventsqs.ServerlessStackProps{
-			Version: "latest",
-			System:  "swarm-example-eventsqs",
-		},
-	)
+	app := eventsqs.NewServerlessApp()
+	stack := app.NewStack("swarm-example-eventsqs", nil)
 	stack.NewQueue()
 
 	stack.NewSink(


### PR DESCRIPTION
* Each Sink Construct is reusable in the context of "foreign" stack
* Built-in stacks are only for simple apps