### PR TITLE
chore: update swarm kernel dependency for all brokers

### DIFF
--- a/broker/embedded/go.mod
+++ b/broker/embedded/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/fogfish/it/v2 v2.2.2
 	github.com/fogfish/logger/x/xlog v0.0.1
 	github.com/fogfish/opts v0.0.5
-	github.com/fogfish/swarm v0.24.0
+	github.com/fogfish/swarm v0.24.1
 )
 
 require (

--- a/broker/embedded/version.go
+++ b/broker/embedded/version.go
@@ -12,4 +12,4 @@ package embedded
 // MAJOR - incompatible api changes
 // MINOR - version of the event kernel
 // PATCH - version of the event bridge module
-const Version = "broker/embedded/v0.24.0"
+const Version = "broker/embedded/v0.24.1"

--- a/broker/eventbridge/go.mod
+++ b/broker/eventbridge/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/fogfish/logger/x/xlog v0.0.1
 	github.com/fogfish/opts v0.0.5
 	github.com/fogfish/scud v0.11.1
-	github.com/fogfish/swarm v0.24.0
+	github.com/fogfish/swarm v0.24.1
 )
 
 require (

--- a/broker/eventbridge/version.go
+++ b/broker/eventbridge/version.go
@@ -12,4 +12,4 @@ package eventbridge
 // MAJOR - incompatible api changes
 // MINOR - version of the event kernel
 // PATCH - version of the event bridge module
-const Version = "broker/eventbridge/v0.24.0"
+const Version = "broker/eventbridge/v0.24.1"

--- a/broker/eventddb/go.mod
+++ b/broker/eventddb/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/fogfish/logger/x/xlog v0.0.1
 	github.com/fogfish/opts v0.0.5
 	github.com/fogfish/scud v0.11.1
-	github.com/fogfish/swarm v0.24.0
+	github.com/fogfish/swarm v0.24.1
 )
 
 require (

--- a/broker/eventddb/version.go
+++ b/broker/eventddb/version.go
@@ -8,4 +8,4 @@
 
 package eventddb
 
-const Version = "broker/eventddb/v0.24.0"
+const Version = "broker/eventddb/v0.24.1"

--- a/broker/events3/go.mod
+++ b/broker/events3/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/fogfish/logger/x/xlog v0.0.1
 	github.com/fogfish/opts v0.0.5
 	github.com/fogfish/scud v0.11.1
-	github.com/fogfish/swarm v0.24.0
+	github.com/fogfish/swarm v0.24.1
 )
 
 require (

--- a/broker/events3/version.go
+++ b/broker/events3/version.go
@@ -8,4 +8,4 @@
 
 package events3
 
-const Version = "broker/events3/v0.24.0"
+const Version = "broker/events3/v0.24.1"

--- a/broker/eventsqs/go.mod
+++ b/broker/eventsqs/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fogfish/logger/x/xlog v0.0.1
 	github.com/fogfish/opts v0.0.5
 	github.com/fogfish/scud v0.11.1
-	github.com/fogfish/swarm v0.24.0
+	github.com/fogfish/swarm v0.24.1
 )
 
 require (

--- a/broker/eventsqs/version.go
+++ b/broker/eventsqs/version.go
@@ -8,4 +8,4 @@
 
 package eventsqs
 
-const Version = "broker/eventsqs/v0.24.0"
+const Version = "broker/eventsqs/v0.24.1"

--- a/broker/sqs/go.mod
+++ b/broker/sqs/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/fogfish/it/v2 v2.2.2
 	github.com/fogfish/logger/x/xlog v0.0.1
 	github.com/fogfish/opts v0.0.5
-	github.com/fogfish/swarm v0.24.0
+	github.com/fogfish/swarm v0.24.1
 )
 
 require (

--- a/broker/sqs/version.go
+++ b/broker/sqs/version.go
@@ -8,4 +8,4 @@
 
 package sqs
 
-const Version = "broker/sqs/v0.24.0"
+const Version = "broker/sqs/v0.24.1"

--- a/broker/websocket/go.mod
+++ b/broker/websocket/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/fogfish/logger/x/xlog v0.0.1
 	github.com/fogfish/opts v0.0.5
 	github.com/fogfish/scud v0.11.1
-	github.com/fogfish/swarm v0.24.0
+	github.com/fogfish/swarm v0.24.1
 )
 
 require (

--- a/broker/websocket/version.go
+++ b/broker/websocket/version.go
@@ -8,4 +8,4 @@
 
 package websocket
 
-const Version = "broker/websocket/v0.24.0"
+const Version = "broker/websocket/v0.24.1"


### PR DESCRIPTION
Update github.com/fogfish/swarm to v0.24.1 and bump PATCH version for all broker modules. 